### PR TITLE
Reducing SD read timeout, allowing the use of machine_sdcard_remount_…

### DIFF
--- a/components/drivers/sd_card/src/sdcard.c
+++ b/components/drivers/sd_card/src/sdcard.c
@@ -166,7 +166,8 @@ static void sd_end_cmd(void)
 static uint8_t sd_get_response(void)
 {
     uint8_t result;
-    uint16_t timeout = 0xFFFF; // min: 0x5f
+    // was set to 0xFFF (values from 95 to 65535)
+    uint16_t timeout = 0xFDE; // min: 0x5f
     /*!< Check if response is got or a timeout is happen */
     while (timeout--)
     {


### PR DESCRIPTION
…obj in order to support hot-plugging microSD.
see: https://github.com/selfcustody/krux/issues/157