### PR TITLE
mount does not imply chdir

### DIFF
--- a/components/micropython/port/src/maixpy_main.c
+++ b/components/micropython/port/src/maixpy_main.c
@@ -175,8 +175,8 @@ STATIC bool init_sdcard_fs(void)
       }
       if (first_part)
       {
-        // use SD card as current directory
-        MP_STATE_PORT(vfs_cur) = vfs;
+        // mount does NOT imply chdir (to avoid importing modules from untrusted sdcard)
+        // MP_STATE_PORT(vfs_cur) = vfs;
         first_part = false;
         break;
       }


### PR DESCRIPTION
in order to avoid importing untrusted code from sdcard

Currently in testing via alternate mpy-cross compiled weak_link modules in root of sdcard for... 
binascii collections errno heapq json math os random struct zlib io re hashlib
