### PR TITLE
GCM: don't validate for aligned plain/ciphertext

### DIFF
--- a/components/micropython/port/src/moducryptolib_maix.c
+++ b/components/micropython/port/src/moducryptolib_maix.c
@@ -61,8 +61,6 @@ typedef struct _mp_obj_aes_t {
     uint8_t gcm_tag[4];
 } mp_obj_aes_t;
 
-const mp_obj_module_t mp_module_ucryptolib;
-
 //------------------------------------------------------------------------------------------------------------------
 STATIC mp_obj_t ucryptolib_aes_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args)
 {
@@ -238,6 +236,7 @@ STATIC mp_obj_t ucryptolib_aes_verify_tag(mp_obj_t self_in, mp_obj_t tag_in) {
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ucryptolib_aes_verify_tag_obj, ucryptolib_aes_verify_tag);
+
 /*
 //----------------------------------------------------
 STATIC mp_obj_t ucryptolib_aes_getIV(mp_obj_t self_in)

--- a/components/micropython/port/src/moducryptolib_maix.c
+++ b/components/micropython/port/src/moducryptolib_maix.c
@@ -126,7 +126,7 @@ STATIC mp_obj_t AES_run(size_t n_args, const mp_obj_t *args, bool encrypt)
     mp_buffer_info_t in_bufinfo;
     mp_get_buffer_raise(in_buf, &in_bufinfo, MP_BUFFER_READ);
 
-    if ((in_bufinfo.len % 16) != 0) {
+    if ((self->mode != UCRYPTOLIB_MODE_GCM) && ((in_bufinfo.len % 16) != 0)) {
         mp_raise_ValueError("input length must be multiple of 16");
     }
 


### PR DESCRIPTION
GCM doesn't require aligned-blocks, so check is avoided.

Prior to the following "krux_encryption" commit, These GCM changes were working fine only because padding to aligned aes-blocks was being done for GCM as it is for ECB/CBC.  However, since the following change, for plaintext/ciphertext that is not aligned, GCM would have been broken.

https://github.com/selfcustody/krux/pull/546/commits/95fc5580847f8552b51e12bc6a13e3bacd7197c7

Since making the changes in this MaixPy pr, I'm no longer having problems with GCM (which is no longer padded in "krux_encryption" branch (pr:456)) and not having problems between device and  simulator using pycryptodome.