### PR TITLE
fix: inverted values for tx / rx for wonderMV

### DIFF
--- a/projects/maixpy_wonder_mv/builtin_py/board.py
+++ b/projects/maixpy_wonder_mv/builtin_py/board.py
@@ -37,8 +37,8 @@ config = json.loads("""
     },
     "board_info": {
         "BOOT_KEY": 16,
-        "CONNEXT_A": 28,
-        "CONNEXT_B": 27,
+        "CONNEXT_A": 27,
+        "CONNEXT_B": 28,
         "I2C_SDA": 19,
         "I2C_SCL": 18,
         "SPI_SCLK": 29,


### PR DESCRIPTION
Tested with printer, the values for rx and tx were inverted